### PR TITLE
propagate ray.button event only when it has focus view

### DIFF
--- a/zsurface/display.c
+++ b/zsurface/display.c
@@ -134,8 +134,9 @@ ray_button(void *data, struct zgn_ray *ray, uint32_t serial, uint32_t time,
   UNUSED(ray);
   struct zsurf_display *surface_display = data;
 
-  surface_display->interaface->pointer_button(
-      surface_display->user_data, serial, time, button, state);
+  if (surface_display->focus_view)
+    surface_display->interaface->pointer_button(
+        surface_display->user_data, serial, time, button, state);
 }
 
 static const struct zgn_ray_listener ray_listener = {


### PR DESCRIPTION
focus しているview がある時だけbutton event を伝えるようにした。